### PR TITLE
Workaround for saving mobile theme on logout/failed login

### DIFF
--- a/elastic4mobile.php
+++ b/elastic4mobile.php
@@ -11,7 +11,7 @@
 class elastic4mobile extends rcube_plugin
 {
     public $noajax = true;
-    public $task = '?(?!logout).*';
+    //public $task = '?(?!logout).*';
 
     public function init()
     {
@@ -21,13 +21,17 @@ class elastic4mobile extends rcube_plugin
         if ($detect->isMobile() || $detect->isTablet()) {
           $skin = 'elastic';
           $rcmail->config->set('skin', $skin);
-          $rcmail->output->set_env('skin', $skin);
           $rcmail->output->set_skin($skin);
+          // Reset default skin, otherwise it will be reset to default in rcmail::kill_session()
+          // TODO: This could be done better
+          $rcmail->default_skin = $skin;
 
           // disable skin switch as this wouldn't have any effect
-          $dont_override = $rcmail->config->get('dont_override', []);
-          $dont_override[] = 'skin';
-          $rcmail->config->set('dont_override', $dont_override);
+          $dont_override = (array) $rcmail->config->get('dont_override');
+          if (!in_array('skin', $dont_override)) {
+            $dont_override[] = 'skin';
+            $rcmail->config->set('dont_override', $dont_override, true);
+          }
         }
     }
 }


### PR DESCRIPTION
Based on @alecpl commit in his pwa plugin: https://git.kolab.org/rRPKbcf5c69735451e1facc00de5be17033ad900cfbf

See https://github.com/thomascube/roundcube-elastic4mobile/issues/4 and https://github.com/thomascube/roundcube-elastic4mobile/issues/5